### PR TITLE
use Config() instead of default_config

### DIFF
--- a/flaskerk/base.py
+++ b/flaskerk/base.py
@@ -2,7 +2,7 @@ from functools import wraps
 from pydantic import ValidationError, BaseModel
 from flask import Blueprint, abort, request, jsonify, make_response, Flask
 
-from flaskerk.config import default_config
+from flaskerk.config import Config
 from flaskerk.view import APIview
 from flaskerk.utils import abort_json, parse_url
 from flaskerk.exception import HTTPException
@@ -26,7 +26,7 @@ class Flaskerk:
 
     def __init__(self, app=None, **configs):
         self.models = {}
-        self.config = default_config
+        self.config = Config()
         self.config._spec = None
         for key, value in configs.items():
             setattr(self.config, key, value)

--- a/flaskerk/config.py
+++ b/flaskerk/config.py
@@ -22,6 +22,3 @@ class Config:
 
         #: private
         self._support_ui = {'redoc', 'swagger'}
-
-
-default_config = Config()

--- a/flaskerk/view.py
+++ b/flaskerk/view.py
@@ -1,8 +1,6 @@
 from flask import render_template, jsonify, abort
 from flask.views import MethodView
 
-from flaskerk.config import default_config
-
 
 class APIview(MethodView):
     def __init__(self, *args, **kwargs):
@@ -11,7 +9,7 @@ class APIview(MethodView):
         super().__init__(*args, **kwargs)
 
     def get(self):
-        assert self.config.ui in default_config._support_ui
+        assert self.config.ui in self.config._support_ui
         ui_file = f'{self.config.ui}.html'
         return render_template(ui_file, spec_url=self.config.filename)
 


### PR DESCRIPTION
If you have multiple instances of Flaskerk, the config may effect each other.

This is useful when you need to have multiple API docs for one service. (like public & private API)