### PR TITLE
Make the SpecTree notice more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ Mainly built for Machine Learning Model services.
 
 If you're using Falcon, check my another library [Falibrary](https://github.com/kemingy/falibrary).
 
-**Attention**
+## Attention
 
-I just build another library [SpecTree](https://github.com/0b01001001/spectree) that supports all the features flaskerk has with better interface. Give it a try!
-
-This library may be archived in the future.
+**I've created a new library named [SpecTree](https://github.com/0b01001001/spectree). It supports all the features of Flaskerk, but with a better interface. Give it a try! This library may be archived in the future.**
 
 ## Features
 


### PR DESCRIPTION
If SpecTree is the new preferred library, then IMHO the notice should be a bit more visible.

- Make the whole notice bold so it stands out more.
- Minor copy tweak to fix grammar.

